### PR TITLE
Generalisation of 'withResource' to allow any instance of MonadCatchIO

### DIFF
--- a/resource-pool.cabal
+++ b/resource-pool.cabal
@@ -30,6 +30,8 @@ library
   build-depends:       
     base == 4.*,
     hashable,
+    MonadCatchIO-transformers,
+    transformers,
     stm,
     time,
     vector >= 0.7


### PR DESCRIPTION
Hello Bryan,

thank you for writing and open-sourcing the resource-pool package. I am using it in one of my projects and it is very useful to me. However, I found the type of the `withResource` function to be too limited for my purpose, so I made some changes which are included in this pull request.

Specifically, I am using resource-pool for pooling database connections inside a "Snap" application (Snap is a Haskell web-framework). Snap provides me with an application-monad which is an instance of `MonadCatchIO`, so that is the type-class I generalised withResource's type to. This allows me to perform other actions in my application monad between database requests.

There are a couple of open points for me though, on which I would love to hear your opinion:
- `MonadCatchIO` is provided by both "mtl" and "transformers". I chose the transformers-version for compatibility with Snap's application monad. I am unsure if there is a consensus in the community which one is "better".
-  High performance is your explicit design goal for resource-pool. I do not know the performace implications of my version versus your original. Perhaps you have some kind of benchmark to measure it?
- Any critique of my code is welcome, although this sample is so small. :-)

Thanks again and cheers,
Falko
