### PR TITLE
Label the reaper thread

### DIFF
--- a/Data/Pool.hs
+++ b/Data/Pool.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE CPP, NamedFieldPuns, RecordWildCards, ScopedTypeVariables #-}
+{-# LANGUAGE CPP, NamedFieldPuns, RecordWildCards, ScopedTypeVariables, RankNTypes #-}
 
 #if MIN_VERSION_monad_control(0,3,0)
 {-# LANGUAGE FlexibleContexts #-}
@@ -40,9 +40,9 @@ module Data.Pool
     ) where
 
 import Control.Applicative ((<$>))
-import Control.Concurrent (forkIO, killThread, myThreadId, threadDelay)
+import Control.Concurrent (ThreadId, forkIOWithUnmask, killThread, myThreadId, threadDelay)
 import Control.Concurrent.STM
-import Control.Exception (SomeException, onException)
+import Control.Exception (SomeException, onException, mask_)
 import Control.Monad (forM_, forever, join, liftM3, unless, when)
 import Data.Hashable (hash)
 import Data.IORef (IORef, newIORef, mkWeakIORef)
@@ -151,10 +151,8 @@ createPool create destroy numStripes idleTime maxResources = do
     modError "pool " $ "invalid maximum resource count " ++ show maxResources
   localPools <- V.replicateM numStripes $
                 liftM3 LocalPool (newTVarIO 0) (newTVarIO []) (newIORef ())
-  reaperId <- forkIO $ do
-                tid <- myThreadId
-                labelThread tid "resource-pool: reaper"
-                reaper destroy idleTime localPools
+  reaperId <- forkIOLabeledWithUnmask "resource-pool: reaper" $ \unmask ->
+                unmask $ reaper destroy idleTime localPools
   fin <- newIORef ()
   let p = Pool {
             create
@@ -168,6 +166,30 @@ createPool create destroy numStripes idleTime maxResources = do
   mkWeakIORef fin (killThread reaperId) >>
     V.mapM_ (\lp -> mkWeakIORef (lfin lp) (purgeLocalPool destroy lp)) localPools
   return p
+
+-- TODO: Propose 'forkIOLabeledWithUnmask' for the base library.
+
+-- | Sparks off a new thread using 'forkIOWithUnmask' to run the given
+-- IO computation, but first labels the thread with the given label
+-- (using 'labelThread').
+--
+-- The implementation makes sure that asynchronous exceptions are
+-- masked until the given computation is executed. This ensures the
+-- thread will always be labeled which guarantees you can always
+-- easily find it in the GHC event log.
+--
+-- Like 'forkIOWithUnmask', the given computation is given a function
+-- to unmask asynchronous exceptions. See the documentation of that
+-- function for the motivation of this.
+--
+-- Returns the 'ThreadId' of the newly created thread.
+forkIOLabeledWithUnmask :: String
+                        -> ((forall a. IO a -> IO a) -> IO ())
+                        -> IO ThreadId
+forkIOLabeledWithUnmask label m = mask_ $ forkIOWithUnmask $ \unmask -> do
+                                    tid <- myThreadId
+                                    labelThread tid label
+                                    m unmask
 
 -- | Periodically go through all pools, closing any resources that
 -- have been left idle for too long.


### PR DESCRIPTION
Hi Bryan,

At Erudify we're doing some GHC event analysis work (using [ghc-events-analyze](http://www.well-typed.com/blog/86)). For that it's important that all threads in our program have a descriptive label. So I would like to push the Haskell community in the direction of labeling all internally created threads with the standard label: `<package-name>: <description>`.

This patch labels the resource-pool's "reaper" thread in that way. 

Note that the second patch fixes a current bug in resource-pool where the reaper thread can not be killed if the user created the pool in a masked context, i.e.:

``` haskell
pool <- mask_ $ createPool ...
```

When pool gets garbage collected the KillThread exception can't be delivered to the reaper thread because it inherited the masked state of the calling thread.

This could lead to a resource leak.

Now we use: `forkIOWithUnmask $ \unmask -> unmask ...`

which ensures asynchronous exception can always be delivered to the reaper thread.
