### PR TITLE
stm 2.3 or greater needed for swapTVar

### DIFF
--- a/resource-pool.cabal
+++ b/resource-pool.cabal
@@ -35,7 +35,7 @@ library
     monad-control >= 0.2.0.1,
     transformers,
     transformers-base >= 0.4,
-    stm,
+    stm >= 2.3,
     time,
     vector >= 0.7
 


### PR DESCRIPTION
Add lower bound for stm to ensure that `swapTVar` exists.
