### PR TITLE
Event-driven reaper

### DIFF
--- a/resource-pool.cabal
+++ b/resource-pool.cabal
@@ -37,7 +37,8 @@ library
     transformers-base >= 0.4,
     stm >= 2.3,
     time,
-    vector >= 0.7
+    vector >= 0.7,
+    alarmclock >= 0.4.0.2
 
   if flag(developer)
     ghc-options: -Werror


### PR DESCRIPTION
Hi,

I'd like to use the resource-pool package, but the polling model for the reaper doesn't work well with what I'm trying to do. Running the reaper every second is too frequent, but simply decreasing the polling frequency means that stale resources will hang around for too long.

I've made an event-driven reaper in the past as part of another project and it worked well before, and I've now extracted this basic functionality into the [alarmclock](http://hackage.haskell.org/package/alarmclock) package.

Would you consider a change to resource-pool to make it use this event-driven model rather than the current polling one? I will prepare a pull request if so.

I'm willing to believe that `alarmclock` is not suitable in its current form, or has some subtle bug or performance issue, so if you have comments for how it could be improved then I'd be glad to hear them.

Cheers,
