### PR TITLE
Fix withResource: should not putResource when any exception occurs

### DIFF
--- a/Data/Pool.hs
+++ b/Data/Pool.hs
@@ -257,9 +257,8 @@ withResource ::
 {-# SPECIALIZE withResource :: Pool a -> (a -> IO b) -> IO b #-}
 withResource pool act = control $ \runInIO -> mask $ \restore -> do
   (resource, local) <- takeResource pool
-  ret <- restore (runInIO (act resource)) `onException`
+  ret <- restore (runInIO (act resource) <* putResource local resource) `onException`
             destroyResource pool local resource
-  putResource local resource
   return ret
 #if __GLASGOW_HASKELL__ >= 700
 {-# INLINABLE withResource #-}


### PR DESCRIPTION
According to the document, withResource should not return the resource to pool when action throws an exception. But the code seems to always call putResource.

In one of my project, the client program use withResource to take a TCP connection from a pool to do sth. But if server program goes down for a while and then come back, the following errors will occur:
"<socket: 20>: hPutBuf: resource vanished (Broken pipe)". That is, the resource in pool contains closed sockets.

With my simple patch, that problem will be gone. New TCP connections will be re-created successfully when server comes online again.
