### PR TITLE
Adding ability to only use/take created resources

### DIFF
--- a/resource-pool.cabal
+++ b/resource-pool.cabal
@@ -1,5 +1,5 @@
 name:                resource-pool
-version:             0.2.3.2
+version:             0.2.4.0
 synopsis:            A high-performance striped resource pooling implementation
 description:
   A high-performance striped pooling abstraction for managing


### PR DESCRIPTION
Extending the try functionality to only work if the resource is created. This is useful for scenarios where we want to ensure existing connections are still valid without having to take the hit in an actual request.