### PR TITLE
Add FIFO queue of waiters

### DIFF
--- a/Data/Pool/WaiterQueue.hs
+++ b/Data/Pool/WaiterQueue.hs
@@ -1,0 +1,87 @@
+module Data.Pool.WaiterQueue
+  ( WaiterQueue,
+    newQueueIO,
+    push,
+    pop,
+  )
+where
+
+import Control.Concurrent.STM
+
+-- | A FIFO queue that supports removing any element from the queue.
+--
+-- We have a pointer to the head of the list, and a pointer to the
+-- final foward pointer in the list.
+data WaiterQueue a
+  = WaiterQueue
+      (TVar (TDList a))
+      (TVar (TVar (TDList a)))
+
+-- | Each element has a pointer to the previous element's forward
+-- pointer where "previous element" can be a 'TDList' cons cell or the
+-- 'WaiterQueue' head pointer.
+data TDList a
+  = TCons
+      (TVar (TVar (TDList a)))
+      a
+      (TVar (TDList a))
+  | TNil
+
+newQueueIO :: IO (WaiterQueue a)
+newQueueIO = do
+  emptyVarL <- newTVarIO TNil
+  emptyVarR <- newTVarIO emptyVarL
+  pure (WaiterQueue emptyVarL emptyVarR)
+
+removeSelf ::
+  -- | 'WaiterQueue's final foward pointer pointer
+  TVar (TVar (TDList a)) ->
+  -- | Our back pointer
+  TVar (TVar (TDList a)) ->
+  -- | Our forward pointter
+  TVar (TDList a) ->
+  STM ()
+removeSelf tv prevPP nextP = do
+  prevP <- readTVar prevPP
+  -- If our back pointer points to our forward pointer then we have
+  -- already been removed from the queue
+  case prevP == nextP of
+    True -> pure ()
+    False -> do
+      next <- readTVar nextP
+      writeTVar prevP next
+      case next of
+        TNil -> writeTVar tv prevP
+        TCons bp _ _ -> writeTVar bp prevP
+      writeTVar prevPP nextP
+{-# INLINE removeSelf #-}
+
+-- | Returns an STM action that removes the pushed element from the
+-- queue
+push :: WaiterQueue a -> a -> STM (STM ())
+push (WaiterQueue _ tv) a = do
+  fwdPointer <- readTVar tv
+  backPointer <- newTVar fwdPointer
+  emptyVar <- newTVar TNil
+  let cell = TCons backPointer a emptyVar
+  writeTVar fwdPointer cell
+  writeTVar tv emptyVar
+  pure (removeSelf tv backPointer emptyVar)
+{-# INLINE push #-}
+
+pop :: WaiterQueue a -> STM (Maybe a)
+pop (WaiterQueue hv tv) = do
+  firstElem <- readTVar hv
+  case firstElem of
+    TNil -> pure Nothing
+    TCons bp a fp -> do
+      f <- readTVar fp
+      writeTVar hv f
+      case f of
+        TNil -> writeTVar tv hv
+        TCons fbp _ _ -> writeTVar fbp hv
+      -- point the back pointer to the forward pointer as a sign that
+      -- the cell has been popped (referenced in removeSelf)
+      writeTVar bp fp
+      pure (Just a)
+{-# INLINE pop #-}

--- a/resource-pool.cabal
+++ b/resource-pool.cabal
@@ -28,6 +28,7 @@ flag developer
 library
   exposed-modules:
     Data.Pool
+  other-modules: Data.Pool.WaiterQueue
 
   build-depends:
     base >= 4.4 && < 5,


### PR DESCRIPTION
Under the current design, resources are kept in a `TVar` pointing to a list of resources. If a thread attempts to acquire a resource and finds the list empty it calls `retry`, adding itself as a waiter to the resource list `TVar`. When the resource `TVar` is later modified all waiters are awoken and free to retry their STM transaction. This is problematic when there are many threads waiting on a resource as they will all be awoken by a thread that puts a resource but only one of the awoken threads will acquire that resource and the rest will fail their validation step. All of these wake ups and retries create some overhead.

To measure this overhead I created a [benchmark](https://github.com/tstat/resource-pool-benchmark) that forks some number of threads, each of which executes the following loop 10 times: acquire a postgresql connection from a pool and execute a simple query that takes a fixed amount of time (using `pg_sleep`). The main thread waits for all forked threads to complete this work. Benchmark output names look like `t=<int>/c=<int>/d=<int>/s=<int>` where `t` is the number of threads forked, `c` is the maximum number of connections the pool allows, `d` is the postgresql query delay in microseconds, and `s` is the number of stripes that `c` is spread over. I am running these benchmarks with the following flags: `--regress=mutatorCpuSeconds:iters +RTS -N20 -A128m -qn2 -I0 -T`.

Looking at the output:

```
benchmarking t=500/c=25/d=2000/s=1 resource-pool
time                 6.158 s    (5.315 s .. 6.560 s)
                     0.998 R²   (0.995 R² .. 1.000 R²)
mean                 5.832 s    (5.631 s .. 5.970 s)
std dev              198.1 ms   (81.93 ms .. 272.8 ms)
mutatorCpuSeconds:   0.997 R²   (0.994 R² .. 1.000 R²)
  iters              109.085    (93.416 .. NaN)
  y                  -13.266    (-36.762 .. 9.157)
variance introduced by outliers: 19% (moderately inflated)

benchmarking t=500/c=25/d=2000/s=5 resource-pool
time                 2.637 s    (2.602 s .. 2.681 s)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 2.740 s    (2.703 s .. 2.791 s)
std dev              58.93 ms   (20.19 ms .. 78.20 ms)
mutatorCpuSeconds:   1.000 R²   (1.000 R² .. 1.000 R²)
  iters              41.539     (40.277 .. NaN)
  y                  2.886      (NaN .. 7.416)
variance introduced by outliers: 19% (moderately inflated)

benchmarking t=500/c=25/d=2000/s=25 resource-pool
time                 1.074 s    (1.037 s .. 1.129 s)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 1.077 s    (1.065 s .. 1.084 s)
std dev              11.47 ms   (5.179 ms .. 14.38 ms)
mutatorCpuSeconds:   0.999 R²   (0.997 R² .. 1.000 R²)
  iters              11.292     (10.340 .. 12.223)
  y                  -0.243     (-2.736 .. 1.030)
variance introduced by outliers: 19% (moderately inflated)
```

We see 109.085 seconds of cpu time consumed when we use one stripe. We can lower this by increasing the number of stripes as fewer threads will be awoken on each put. With 25 stripes of 1 connection we reduce the cpu time consumed to 11.292 seconds, and our running time is reduced from 6.158 seconds to 1.074 seconds. Of course, we are unfairly favoring high striping in this benchmark since each thread does the exact same amount of work. In an actual application with uneven work across threads this would have undesirable consequences.

It is clear that performance improves if we wake up fewer threads, and an ideal scenario would be if we woke up at most one thread when a resource is returned. To this end, I propose that we add a FIFO queue of `TMVar (Entry a)` to the pool. When a thread attempts to acquire a resource it first checks the available resource list. If this list is empty then the thread adds an empty `TMVar` to the waiter queue and waits on it. When returning a resource to the pool the returning thread first checks if there are any waiters in the queue, and if so returns straight to the waiter, waking up only 1 thread.

There is a complication though: a waiting thread might be killed, and if so we don't want to put a resource into its `TMVar`. To avoid this issue the queue implemented in this PR allows for removing any entry from the queue. Any thread that enqueues a `TMVar` and blocks on reading it first installs an exception handler that removes itself from the queue and returns the resource to the pool if it has already been put into its `TMVar`. 

The benchmark shows promising results for this change:
```
benchmarking t=500/c=25/d=2000/s=1 resource-pool-patched
time                 469.3 ms   (468.9 ms .. 469.7 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 469.1 ms   (468.9 ms .. 469.2 ms)
std dev              158.2 μs   (62.94 μs .. 213.0 μs)
mutatorCpuSeconds:   1.000 R²   (1.000 R² .. 1.000 R²)
  iters              0.148      (0.146 .. 0.153)
  y                  -9.138e-4  (-7.374e-3 .. 6.396e-3)
variance introduced by outliers: 19% (moderately inflated)
```
Here we see the benchmark ran against this PR with a single stripe and the running time is less than half the running time of the above 25 stripe pool while cpu time is less than 2% the cpu time consumed by the 25 stripe pool. Indeed, with this PR I did not run a benchmark where striping would be beneficial.

The full results may be found [here](https://tstat.github.io/resource-pool-benchmark/out/hasql.txt) and the html output may be found [here](https://tstat.github.io/resource-pool-benchmark/out/hasql.html).
